### PR TITLE
[no-id]: Remove #define MOODYCAMEL_EXCEPTIONS_ENABLED commit was not merged to master

### DIFF
--- a/concurrentqueue.h
+++ b/concurrentqueue.h
@@ -1,4 +1,4 @@
-﻿// Provides a C++11 implementation of a multi-producer, multi-consumer lock-free queue.
+// Provides a C++11 implementation of a multi-producer, multi-consumer lock-free queue.
 // An overview, including benchmark results, is provided here:
 //     http://moodycamel.com/blog/2014/a-fast-general-purpose-lock-free-queue-for-c++
 // The full design is also described in excruciating detail at:
@@ -153,7 +153,7 @@ namespace moodycamel { namespace details {
 // Exceptions
 #ifndef MOODYCAMEL_EXCEPTIONS_ENABLED
 #if (defined(_MSC_VER) && defined(_CPPUNWIND)) || (defined(__GNUC__) && defined(__EXCEPTIONS)) || (!defined(_MSC_VER) && !defined(__GNUC__))
-#define MOODYCAMEL_EXCEPTIONS_ENABLED
+// #define MOODYCAMEL_EXCEPTIONS_ENABLED
 #endif
 #endif
 #ifdef MOODYCAMEL_EXCEPTIONS_ENABLED


### PR DESCRIPTION
`Crowbar disable exceptions` commit which removed `#define MOODYCAMEL_EXCEPTIONS_ENABLED` was mistakenly not merged to master but was referenced as a submodule in another repo. This moves that commit to master so another change can be made.